### PR TITLE
(SERVER-1920) Update testing module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-puppet-grafanadash
+puppetlabs-grafanadash
 ==================
 
 This is just a dev module; it installs a very simple configuration of
-graphite, grafana, and elasticsearch.  Tested only on a clean cent6 box.
+graphite, grafana, and elasticsearch.  Tested only on a clean cent7 box.
 
-WARNING: totally insecure.  Turns off selinux and iptables.  Enables CORS on apache.
+**WARNING: totally insecure.  Turns off selinux and iptables.  Enables CORS on apache.**
 
 Usage:
 
-    puppet module install cprice404-grafanadash
+    puppet module install puppetlabs-grafanadash
 
     puppet apply -e 'include grafanadash::dev'
 

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -1,6 +1,6 @@
 class grafanadash::dev() {
   # hack; there is probably a module for this
-  exec { '/usr/sbin/setenforce 0': }
+  exec { '/usr/sbin/setenforce 0 || /bin/true': }
 
   # this is stupid, for anything other than dev
   service { 'iptables':

--- a/manifests/grafana.pp
+++ b/manifests/grafana.pp
@@ -13,11 +13,15 @@ class grafanadash::grafana (
   $grafana_host       = $grafanadash::grafana::params::grafana_host,
   $grafana_port       = $grafanadash::grafana::params::grafana_port,
 ) inherits grafanadash::grafana::params {
-  archive { "grafana-${version}":
-    ensure   => present,
-    url      => $download_url,
-    target   => $install_dir,
-    checksum => false,
+
+  $archive = "${install_dir}/grafana-${version}.tar.gz"
+
+  archive { $archive:
+    ensure       => present,
+    source       => $download_url,
+    extract      => true,
+    extract_path => $install_dir,
+    creates      => "${install_dir}/grafana-${version}",
   } ->
 
   file { "${install_dir}/grafana-${version}/config.js":
@@ -25,13 +29,13 @@ class grafanadash::grafana (
     content => template('grafanadash/opt/grafana/config.js.erb'),
     owner   => $user,
     group   => $group,
-    require => Archive["grafana-${version}"],
+    require => Archive[$archive],
   } ->
 
   file { $symlink_name:
     ensure  => link,
     target  => "${install_dir}/grafana-${version}",
-    require => Archive["grafana-${version}"],
+    require => Archive[$archive],
   } ->
 
   file { "${::graphite::params::apacheconf_dir}/grafana.conf":

--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,6 @@
     { "name": "dwerder/graphite", "version_requirement": "7.1.0" },
     { "name": "puppet/archive", "version_requirement": "1.3.0" },
     { "name": "stahnma/epel", "version_requirement": "1.2.2" },
-    { "name": "elasticsearch/elasticsearch", "version_requirement": "0.3.2"}
+    { "name": "elastic/elasticsearch", "version_requirement": "5.4.1"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
-  "name": "cprice404-grafanadash",
-  "version": "0.0.6",
-  "source": "git clone https://github.com/cprice404/puppet-grafanadash",
+  "name": "puppetlabs-grafanadash",
+  "version": "1.0.0",
+  "source": "https://github.com/puppetlabs/puppetlabs-grafanadash",
   "author": "Chris Price",
   "license": "Mozilla Public License Version 2.0",
-  "summary": "Grafana Dashboard module",
-  "description": "Installs graphite and grafana",
-  "project_page": "https://github.com/cprice404/puppet-grafanadash",
+  "summary": "Grafana Dashboard module for testing purposes",
+  "description": "Installs graphite and grafana for Puppetlabs testing purposes. Only supports EL 7.",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-grafanadash",
 
   "dependencies": [
     { "name": "dwerder/graphite", "version_requirement": "7.1.0" },

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
 
   "dependencies": [
     { "name": "dwerder/graphite", "version_requirement": "7.1.0" },
-    { "name": "gini/archive", "version_requirement": "0.2.0" },
+    { "name": "puppet/archive", "version_requirement": "1.3.0" },
     { "name": "stahnma/epel", "version_requirement": "1.2.2" },
     { "name": "elasticsearch/elasticsearch", "version_requirement": "0.3.2"}
   ]


### PR DESCRIPTION
Previously we were using an old module from Chris that had a lot of really old dependencies to test Graphite/Grafana compatabilities on Cent 6. Our dependencies have broken and no longer seem to be maintained (the old versions that Chris' module depended on). This moves the module into the Puppetlabs namespace and updates the module to modern dependencies so we can run it on Cent7.