### PR TITLE
(MAINT) Add dependencies to fix graphite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+**1.0.1**
+  - Bugfix: Add pycairo and libdrm dependencies for graphite
+
 **1.0.0**
   - Move to using CentOS 7 from CentOS 6

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -13,6 +13,15 @@ class grafanadash::dev() {
     ensure => present,
   } ->
 
+  # graphite's /render endpoints throws errors when these dependencies are missing/not updated
+  package { 'pycairo':
+    ensure => latest,
+  } ->
+
+  package { 'libdrm':
+    ensure => latest,
+  } ->
+
   class { 'epel': } ->
 
   class { 'graphite':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-grafanadash",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "source": "https://github.com/puppetlabs/puppetlabs-grafanadash",
   "author": "Chris Price",
   "license": "Mozilla Public License Version 2.0",


### PR DESCRIPTION
It seems that graphite needs the pycairo and libdrm packages on el7 in order for the
/render endpoint to function. Otherwise it returns a 500 status code